### PR TITLE
Split functions to parse gpx data and factor out track parsing

### DIFF
--- a/DESCRIPTION
+++ b/DESCRIPTION
@@ -1,7 +1,7 @@
 Type: Package
 Package: osmapiR
 Title: 'OpenStreetMap' API
-Version: 0.1.0.9004
+Version: 0.1.0.9005
 Authors@R: c(
     person("Joan", "Maspons", , "joanmaspons@gmail.com", role = c("aut", "cre", "cph"),
            comment = c(ORCID = "0000-0003-2286-8727")),

--- a/NEWS.md
+++ b/NEWS.md
@@ -8,6 +8,7 @@
 * Add format = "sf" for `osm_get_gpx_metadata()` (#38)
 * Updated links to the new osmapiR home at rOpenSci (#40)
 * Add format = "sf" for `osm_list_gpxs()` (#42)
+* Split functions to parse gpx data from different API endpoints and different properties (#43)
 
 # osmapiR 0.1.0
 

--- a/R/osmapi_gps_traces.R
+++ b/R/osmapi_gps_traces.R
@@ -109,13 +109,6 @@
 
   if (format == "R") {
     out <- gpx_xml2list(obj_xml)
-    names(out) <- vapply(out, function(x) {
-      url <- attr(x, "url")
-      if (is.null(url)) { # for private traces?
-        url <- ""
-      }
-      url
-    }, FUN.VALUE = character(1))
   } else {
     out <- obj_xml
   }
@@ -422,22 +415,8 @@ osm_get_data_gpx <- function(gpx_id, format) {
   if (missing(format) || format %in% c("xml", "gpx")) {
     out <- obj_xml
   } else {
-    out <- gpx_xml2list(obj_xml)
+    out <- gpx_xml2df(obj_xml)
 
-    if (length(out) > 1) {
-      warning(
-        "Unexpected output format at osm_get_data_gpx().",
-        "Please, open and issue with the `gpx_id` or the original file if the gpx is not public ",
-        "at https://github.com/ropensci/osmapiR/issues"
-      )
-    } else {
-      attrs <- attributes(out)
-      attrs <- attrs[setdiff(names(attrs), "class")]
-      names(attrs) <- paste0("gpx_", names(attrs))
-      out <- out[[1]]
-      attributes(out) <- c(attributes(out), attrs)
-      class(out) <- c("osmapi_gps_track", "data.frame")
-    }
   }
 
   return(out)

--- a/codemeta.json
+++ b/codemeta.json
@@ -8,7 +8,7 @@
   "codeRepository": "https://github.com/ropensci/osmapiR",
   "issueTracker": "https://github.com/ropensci/osmapiR/issues",
   "license": "https://spdx.org/licenses/GPL-3.0",
-  "version": "0.1.0.9004",
+  "version": "0.1.0.9005",
   "programmingLanguage": {
     "@type": "ComputerLanguage",
     "name": "R",
@@ -163,7 +163,7 @@
     "SystemRequirements": null
   },
   "keywords": ["openstreetmap", "OSM", "openstreetmap-api", "osmapi", "API", "osm", "r", "r-package"],
-  "fileSize": "14112.96KB",
+  "fileSize": "14113.689KB",
   "citation": [
     {
       "@type": "SoftwareSourceCode",
@@ -180,7 +180,7 @@
       "name": "osmapiR: OpenStreetMap API",
       "identifier": "10.32614/CRAN.package.osmapiR",
       "url": "https://docs.ropensci.org/osmapiR/",
-      "description": "R package version 0.1.0.9003 \nhttps://github.com/ropensci/osmapiR",
+      "description": "R package version 0.1.0.9005 \nhttps://github.com/ropensci/osmapiR",
       "@id": "https://doi.org/10.32614/CRAN.package.osmapiR",
       "sameAs": "https://doi.org/10.32614/CRAN.package.osmapiR"
     }

--- a/tests/testthat/test-gps_traces.R
+++ b/tests/testthat/test-gps_traces.R
@@ -169,6 +169,8 @@ test_that("osm_get_metadata_gpx works", {
 test_that("osm_get_data_gpx works", {
   trk_data <- list()
   with_mock_dir("mock_get_data_gpx", {
+    # gpx_id = 3458743: creator="JOSM GPX export" <metadata> bounds c("minlat", "minlon", "maxlat", "maxlon")
+    # gpx_id = 3498170: creator="Garmin Connect"
     trk_data$raw <- osm_get_data_gpx(gpx_id = 3458743)
     trk_data$gpx <- osm_get_data_gpx(gpx_id = 3458743, format = "gpx") # identical to xml resp but heavier mock file
     ## gpx responses has `content-type` = "application/gpx+xml and httptest2 save them as raw instead of xml files


### PR DESCRIPTION
* gpx_xml2df() for calls to osm osm_get_data_gpx(id)
* gpx_xml2list() for calls to osm_get_points_gps(bbox)
* may break former attribute structure for results in `format = R` (minor changes)