### PR TITLE
fix: use standard way to find version

### DIFF
--- a/inst/CITATION
+++ b/inst/CITATION
@@ -3,7 +3,7 @@ bibentry(
   title    = "osmapiR: OpenStreetMap API",
   author   = person("Joan", "Maspons", , "joanmaspons@gmail.com", role = c("aut", "cre", "cph"),
                     comment = c(ORCID = "0000-0003-2286-8727")),
-  note     = paste0("R package version ",  utils::packageVersion("osmapiR"), " \nhttps://github.com/ropensci/osmapiR"),
+  note     = paste0("R package version ",  meta$Version, " \nhttps://github.com/ropensci/osmapiR"),
   year     = 2024,
   url      = "https://docs.ropensci.org/osmapiR/",
   doi      = "10.32614/CRAN.package.osmapiR"


### PR DESCRIPTION
Example: https://github.com/ropensci/GSODR/blob/7404aca8b9b258be473985e5fce39291f9814606/inst/CITATION#L9

With this change, {codemeta} will be able to read the CITATION file when the package is not installed, which is what happens when we try to build rOpenSci registry.

Once you merge this, the daily registry build from https://github.com/ropensci/roregistry should include your package. 

cc @jeroen 