### PR TITLE
Update documentation and code from OSMWikiVersion: 2711808 to 2775892  

### DIFF
--- a/DESCRIPTION
+++ b/DESCRIPTION
@@ -34,5 +34,6 @@ Config/testthat/edition: 3
 Encoding: UTF-8
 Roxygen: list(markdown = TRUE)
 RoxygenNote: 7.3.1
+OSMWikiVersion: 2711808
 X-schema.org-keywords: open street map, openstreetmap, OSM,
     openstreetmap-api, osmapi, API

--- a/DESCRIPTION
+++ b/DESCRIPTION
@@ -1,7 +1,7 @@
 Type: Package
 Package: osmapiR
 Title: 'OpenStreetMap' API
-Version: 0.2.1.9001
+Version: 0.2.1.9002
 Authors@R: c(
     person("Joan", "Maspons", , "joanmaspons@gmail.com", role = c("aut", "cre", "cph"),
            comment = c(ORCID = "0000-0003-2286-8727")),
@@ -33,7 +33,7 @@ VignetteBuilder:
 Config/testthat/edition: 3
 Encoding: UTF-8
 Roxygen: list(markdown = TRUE)
-RoxygenNote: 7.3.1
-OSMWikiVersion: 2711808
+RoxygenNote: 7.3.2
+OSMWikiVersion: 2775892
 X-schema.org-keywords: open street map, openstreetmap, OSM,
     openstreetmap-api, osmapi, API

--- a/NEWS.md
+++ b/NEWS.md
@@ -1,7 +1,10 @@
 # osmapiR (development version)
 
 * Use the new function `httr2::oauth_cache_clear()` from httr2 1.0.6 (#58 by @hadley).
-* Update documentation and code for server-side changes documented in OSMWikiVersion 2775892 (#60).
+* Update documentation and code for server-side changes documented in OSMWikiVersion
+  [2711808 -> 2775892](https://wiki.openstreetmap.org/w/index.php?title=API_v0.6&type=revision&diff=2775892&oldid=2711808)
+  (#60).
+  * Add new parameters to `osm_query_changesets(..., from, to)`.
 
 # osmapiR 0.2.1
 

--- a/NEWS.md
+++ b/NEWS.md
@@ -1,6 +1,7 @@
 # osmapiR (development version)
 
 * Use the new function `httr2::oauth_cache_clear()` from httr2 1.0.6 (#58 by @hadley).
+* Update documentation and code for server-side changes documented in OSMWikiVersion 2775892 (#60).
 
 # osmapiR 0.2.1
 

--- a/R/osm_get_changesets.R
+++ b/R/osm_get_changesets.R
@@ -26,48 +26,66 @@
 #' ## `format = "xml"`
 #' Returns a [xml2::xml_document-class] with the following format:
 #' ``` xml
-#' <osm>
-#' 	<changeset id="10" created_at="2008-11-08T19:07:39+01:00" open="true" user="fred" uid="123" min_lon="7.0191821" min_lat="49.2785426" max_lon="7.0197485" max_lat="49.2793101" comments_count="3" changes_count="10">
-#' 		<tag k="created_by" v="JOSM 1.61"/>
-#' 		<tag k="comment" v="Just adding some streetnames"/>
-#' 		...
-#' 		<discussion>
-#' 			<comment date="2015-01-01T18:56:48Z" uid="1841" user="metaodi">
-#' 				<text>Did you verify those street names?</text>
-#' 			</comment>
-#' 			<comment date="2015-01-01T18:58:03Z" uid="123" user="fred">
-#' 				<text>sure!</text>
-#' 			</comment>
-#' 			...
-#' 		</discussion>
-#' 	</changeset>
-#' 	<changeset>
-#' 	  ...
-#' 	</changeset>
+#' <osm version="0.6" generator="CGImap 0.9.3 (987909 spike-08.openstreetmap.org)" copyright="OpenStreetMap and contributors" attribution="http://www.openstreetmap.org/copyright" license="http://opendatacommons.org/licenses/odbl/1-0/">
+#'   <changeset id="10" created_at="2008-11-08T19:07:39+01:00" open="true" user="fred" uid="123" min_lon="7.0191821" min_lat="49.2785426" max_lon="7.0197485" max_lat="49.2793101" comments_count="3" changes_count="10">
+#'     <tag k="created_by" v="JOSM 1.61"/>
+#'     <tag k="comment" v="Just adding some streetnames"/>
+#'     ...
+#'     <discussion>
+#'       <comment id="1234" date="2015-01-01T18:56:48Z" uid="1841" user="metaodi">
+#'         <text>Did you verify those street names?</text>
+#'       </comment>
+#'       <comment id="5678" date="2015-01-01T18:58:03Z" uid="123" user="fred">
+#'         <text>sure!</text>
+#'       </comment>
+#'       ...
+#'     </discussion>
+#'   </changeset>
+#'   <changeset>
+#'     ...
+#'   </changeset>
 #' </osm>
 #' ```
 #'
 #' ## `format = "json"`
+#' *Please note that the JSON format has changed on August 25, 2024 with the release of openstreetmap-cgimap 2.0.0, to*
+#' *align it with the existing Rails format.*
+#'
 #' Returns a list with the following json structure:
 #' ``` json
 #' {
-#'  "version": "0.6",
-#'  "elements": [
-#'   {"type": "changeset",
-#'    "id": 10,
-#'    "created_at": "2005-05-01T16:09:37Z",
-#'    "closed_at": "2005-05-01T17:16:44Z",
-#'    "open": False,
-#'    "user": "Petter Reinholdtsen",
-#'    "uid": 24,
-#'    "minlat": 59.9513092,
-#'    "minlon": 10.7719727,
-#'    "maxlat": 59.9561501,
-#'    "maxlon": 10.7994537,
-#'    "comments_count": 1,
-#'    "changes_count": 10,
-#'    "discussion": [{"date": "2022-03-22T20:58:30Z", "uid": 15079200, "user": "Ethan White of Cheriton", "text": "wow no one have said anything here 3/22/2022\n"}]
-#'   }, ...]
+#'   "version": "0.6",
+#'   "generator": "openstreetmap-cgimap 2.0.0 (4003517 spike-08.openstreetmap.org)",
+#'   "copyright": "OpenStreetMap and contributors",
+#'   "attribution": "http://www.openstreetmap.org/copyright",
+#'   "license": "http://opendatacommons.org/licenses/odbl/1-0/",
+#'   "changeset": [
+#'     {
+#'       "id": 10,
+#'       "created_at": "2005-05-01T16:09:37Z",
+#'       "open": false,
+#'       "comments_count": 1,
+#'       "changes_count": 10,
+#'       "closed_at": "2005-05-01T17:16:44Z",
+#'       "min_lat": 59.9513092,
+#'       "min_lon": 10.7719727,
+#'       "max_lat": 59.9561501,
+#'       "max_lon": 10.7994537,
+#'       "uid": 24,
+#'       "user": "Petter Reinholdtsen",
+#'       "comments": [
+#'         {
+#'           "id": 836447,
+#'           "visible": true,
+#'           "date": "2022-03-22T20:58:30Z",
+#'           "uid": 15079200,
+#'           "user": "Ethan White of Cheriton",
+#'           "text": "wow no one have said anything here 3/22/2022\n"
+#'         }
+#'       ]
+#'     },
+#'     ...
+#'   ]
 #' }
 #' ```
 #'

--- a/R/osm_query_changesets.R
+++ b/R/osm_query_changesets.R
@@ -42,48 +42,51 @@
 #' ## `format = "xml"`
 #' Returns a [xml2::xml_document-class] with the following format:
 #' ``` xml
-#' <osm>
-#' 	<changeset id="10" created_at="2008-11-08T19:07:39+01:00" open="true" user="fred" uid="123" min_lon="7.0191821" min_lat="49.2785426" max_lon="7.0197485" max_lat="49.2793101" comments_count="3" changes_count="10">
-#' 		<tag k="created_by" v="JOSM 1.61"/>
-#' 		<tag k="comment" v="Just adding some streetnames"/>
-#' 		...
-#' 		<discussion>
-#' 			<comment date="2015-01-01T18:56:48Z" uid="1841" user="metaodi">
-#' 				<text>Did you verify those street names?</text>
-#' 			</comment>
-#' 			<comment date="2015-01-01T18:58:03Z" uid="123" user="fred">
-#' 				<text>sure!</text>
-#' 			</comment>
-#' 			...
-#' 		</discussion>
-#' 	</changeset>
-#' 	<changeset ...>
-#' 	  ...
-#' 	</changeset>
+#' <osm version="0.6" generator="OpenStreetMap server" copyright="OpenStreetMap and contributors" attribution="http://www.openstreetmap.org/copyright" license="http://opendatacommons.org/licenses/odbl/1-0/">
+#'   <changeset id="10" created_at="2005-05-01T16:09:37Z" open="false" comments_count="1" changes_count="10" closed_at="2005-05-01T17:16:44Z" min_lat="59.9513092" min_lon="10.7719727" max_lat="59.9561501" max_lon="10.7994537" uid="24" user="Petter Reinholdtsen">
+#'     <tag k="created_by" v="JOSM 1.61"/>
+#'     <tag k="comment" v="Just adding some streetnames"/>
+#'     ...
+#'   </changeset>
+#'   <changeset ...>
+#'     ...
+#'   </changeset>
 #' </osm>
 #' ```
 #'
 #' ## `format = "json"`
+#' *Please note that the JSON format has changed on August 25, 2024 with the release of openstreetmap-cgimap 2.0.0, to*
+#' *align it with the existing Rails format.*
+#'
 #' Returns a list with the following json structure:
 #' ``` json
 #' {
-#'  "version": "0.6",
-#'  "elements": [
-#'   {"type": "changeset",
-#'    "id": 10,
-#'    "created_at": "2005-05-01T16:09:37Z",
-#'    "closed_at": "2005-05-01T17:16:44Z",
-#'    "open": False,
-#'    "user": "Petter Reinholdtsen",
-#'    "uid": 24,
-#'    "minlat": 59.9513092,
-#'    "minlon": 10.7719727,
-#'    "maxlat": 59.9561501,
-#'    "maxlon": 10.7994537,
-#'    "comments_count": 1,
-#'    "changes_count": 10,
-#'    "discussion": [{"date": "2022-03-22T20:58:30Z", "uid": 15079200, "user": "Ethan White of Cheriton", "text": "wow no one have said anything here 3/22/2022\n"}]
-#'   }, ...]
+#'   "version": "0.6",
+#'   "generator": "openstreetmap-cgimap 2.0.0 (4003517 spike-08.openstreetmap.org)",
+#'   "copyright": "OpenStreetMap and contributors",
+#'   "attribution": "http://www.openstreetmap.org/copyright",
+#'   "license": "http://opendatacommons.org/licenses/odbl/1-0/",
+#'   "changesets": [
+#'     {
+#'       "id": 10,
+#'       "created_at": "2005-05-01T16:09:37Z",
+#'       "open": false,
+#'       "comments_count": 1,
+#'       "changes_count": 10,
+#'       "closed_at": "2005-05-01T17:16:44Z",
+#'       "min_lat": 59.9513092,
+#'       "min_lon": 10.7719727,
+#'       "max_lat": 59.9561501,
+#'       "max_lon": 10.7994537,
+#'       "uid": 24,
+#'       "user": "Petter Reinholdtsen",
+#'       "tags": {
+#'           "comment": "Just adding some streetnames",
+#'           "created_by": "JOSM 1.61"
+#'       }
+#'     },
+#'     ...
+#'   ]
 #' }
 #' ```
 #'

--- a/R/osmapi_changesets.R
+++ b/R/osmapi_changesets.R
@@ -238,16 +238,16 @@ osm_create_changeset <- function(comment, ...,
 #' ## `format = "xml"`
 #' Returns a [xml2::xml_document-class] with the following format:
 #' ``` xml
-#' <osm>
+#' <osm version="0.6" generator="CGImap 0.9.3 (987909 spike-08.openstreetmap.org)" copyright="OpenStreetMap and contributors" attribution="http://www.openstreetmap.org/copyright" license="http://opendatacommons.org/licenses/odbl/1-0/">
 #' 	<changeset id="10" created_at="2008-11-08T19:07:39+01:00" open="true" user="fred" uid="123" min_lon="7.0191821" min_lat="49.2785426" max_lon="7.0197485" max_lat="49.2793101" comments_count="3" changes_count="10">
 #' 		<tag k="created_by" v="JOSM 1.61"/>
 #' 		<tag k="comment" v="Just adding some streetnames"/>
 #' 		...
 #' 		<discussion>
-#' 			<comment date="2015-01-01T18:56:48Z" uid="1841" user="metaodi">
+#' 			<comment id="1234" date="2015-01-01T18:56:48Z" uid="1841" user="metaodi">
 #' 				<text>Did you verify those street names?</text>
 #' 			</comment>
-#' 			<comment date="2015-01-01T18:58:03Z" uid="123" user="fred">
+#' 			<comment id="5678" date="2015-01-01T18:58:03Z" uid="123" user="fred">
 #' 				<text>sure!</text>
 #' 			</comment>
 #' 			...
@@ -257,26 +257,41 @@ osm_create_changeset <- function(comment, ...,
 #' ```
 #'
 #' ## `format = "json"`
+#' *Please note that the JSON format has changed on August 25, 2024 with the release of openstreetmap-cgimap 2.0.0, to*
+#' *align it with the existing Rails format.*
+#'
 #' Returns a list with the following json structure:
 #' ``` json
 #' {
-#'  "version": "0.6",
-#'  "elements": [
-#'   {"type": "changeset",
-#'    "id": 10,
-#'    "created_at": "2005-05-01T16:09:37Z",
-#'    "closed_at": "2005-05-01T17:16:44Z",
-#'    "open": False,
-#'    "user": "Petter Reinholdtsen",
-#'    "uid": 24,
-#'    "minlat": 59.9513092,
-#'    "minlon": 10.7719727,
-#'    "maxlat": 59.9561501,
-#'    "maxlon": 10.7994537,
-#'    "comments_count": 1,
-#'    "changes_count": 10,
-#'    "discussion": [{"date": "2022-03-22T20:58:30Z", "uid": 15079200, "user": "Ethan White of Cheriton", "text": "wow no one have said anything here 3/22/2022\n"}]
-#'   }]
+#'   "version": "0.6",
+#'   "generator": "openstreetmap-cgimap 2.0.0 (4003517 spike-08.openstreetmap.org)",
+#'   "copyright": "OpenStreetMap and contributors",
+#'   "attribution": "http://www.openstreetmap.org/copyright",
+#'   "license": "http://opendatacommons.org/licenses/odbl/1-0/",
+#'   "changeset": {
+#'     "id": 10,
+#'     "created_at": "2005-05-01T16:09:37Z",
+#'     "open": false,
+#'     "comments_count": 1,
+#'     "changes_count": 10,
+#'     "closed_at": "2005-05-01T17:16:44Z",
+#'     "min_lat": 59.9513092,
+#'     "min_lon": 10.7719727,
+#'     "max_lat": 59.9561501,
+#'     "max_lon": 10.7994537,
+#'     "uid": 24,
+#'     "user": "Petter Reinholdtsen",
+#'     "comments": [
+#'       {
+#'         "id": 836447,
+#'         "visible": true,
+#'         "date": "2022-03-22T20:58:30Z",
+#'         "uid": 15079200,
+#'         "user": "Ethan White of Cheriton",
+#'         "text": "wow no one have said anything here 3/22/2022\n"
+#'       }
+#'     ]
+#'   }
 #' }
 #' ```
 #'
@@ -538,7 +553,7 @@ osm_download_changeset <- function(changeset_id, format = c("R", "osc", "xml")) 
 
 #' Query changesets
 #'
-#' This is an API method for querying changesets. It supports querying by different criteria.
+#' This is an API method for getting a list of changesets. It supports filtering by different criteria.
 #'
 #' @param bbox Find changesets within the given bounding box coordinates (`left,bottom,right,top`).
 #' @param user Find changesets by the user with the given user id (numeric) or display name (character).
@@ -565,8 +580,8 @@ osm_download_changeset <- function(changeset_id, format = c("R", "osc", "xml")) 
 #' Modification and extension of the basic queries above may be required to support rollback and other uses we find for
 #' changesets.
 #'
-#' This call returns latest changesets matching criteria. The default ordering is newest first, but you can specify
-#' `order="oldest"` to reverse the sort order (see
+#' This call returns changesets matching criteria, ordered by their creation time. The default ordering is newest first,
+#' but you can specify `order="oldest"` to reverse the sort order (see
 #' [ordered by `created_at`](https://github.com/openstreetmap/openstreetmap-website/blob/f1c6a87aa137c11d0aff5a4b0e563ac2c2a8f82d/app/controllers/api/changesets_controller.rb#L174)
 #' – see the [current state](https://github.com/openstreetmap/openstreetmap-website/blob/master/app/controllers/api/changesets_controller.rb#L174)).
 #' Reverse ordering cannot be combined with `time`.
@@ -580,24 +595,15 @@ osm_download_changeset <- function(changeset_id, format = c("R", "osc", "xml")) 
 #' ## `format = "xml"`
 #' Returns a [xml2::xml_document-class] with the following format:
 #' ``` xml
-#' <osm>
-#' 	<changeset id="10" created_at="2008-11-08T19:07:39+01:00" open="true" user="fred" uid="123" min_lon="7.0191821" min_lat="49.2785426" max_lon="7.0197485" max_lat="49.2793101" comments_count="3" changes_count="10">
-#' 		<tag k="created_by" v="JOSM 1.61"/>
-#' 		<tag k="comment" v="Just adding some streetnames"/>
-#' 		...
-#' 		<discussion>
-#' 			<comment date="2015-01-01T18:56:48Z" uid="1841" user="metaodi">
-#' 				<text>Did you verify those street names?</text>
-#' 			</comment>
-#' 			<comment date="2015-01-01T18:58:03Z" uid="123" user="fred">
-#' 				<text>sure!</text>
-#' 			</comment>
-#' 			...
-#' 		</discussion>
-#' 	</changeset>
-#' 	<changeset ...>
-#' 	  ...
-#' 	</changeset>
+#' <osm version="0.6" generator="OpenStreetMap server" copyright="OpenStreetMap and contributors" attribution="http://www.openstreetmap.org/copyright" license="http://opendatacommons.org/licenses/odbl/1-0/">
+#'   <changeset id="10" created_at="2005-05-01T16:09:37Z" open="false" comments_count="1" changes_count="10" closed_at="2005-05-01T17:16:44Z" min_lat="59.9513092" min_lon="10.7719727" max_lat="59.9561501" max_lon="10.7994537" uid="24" user="Petter Reinholdtsen">
+#'     <tag k="created_by" v="JOSM 1.61"/>
+#'     <tag k="comment" v="Just adding some streetnames"/>
+#'     ...
+#'   </changeset>
+#'   <changeset ...>
+#'     ...
+#'   </changeset>
 #' </osm>
 #' ```
 #'
@@ -605,23 +611,32 @@ osm_download_changeset <- function(changeset_id, format = c("R", "osc", "xml")) 
 #' Returns a list with the following json structure:
 #' ``` json
 #' {
-#'  "version": "0.6",
-#'  "elements": [
-#'   {"type": "changeset",
-#'    "id": 10,
-#'    "created_at": "2005-05-01T16:09:37Z",
-#'    "closed_at": "2005-05-01T17:16:44Z",
-#'    "open": False,
-#'    "user": "Petter Reinholdtsen",
-#'    "uid": 24,
-#'    "minlat": 59.9513092,
-#'    "minlon": 10.7719727,
-#'    "maxlat": 59.9561501,
-#'    "maxlon": 10.7994537,
-#'    "comments_count": 1,
-#'    "changes_count": 10,
-#'    "discussion": [{"date": "2022-03-22T20:58:30Z", "uid": 15079200, "user": "Ethan White of Cheriton", "text": "wow no one have said anything here 3/22/2022\n"}]
-#'   }, ...]
+#'   "version": "0.6",
+#'   "generator": "openstreetmap-cgimap 2.0.0 (4003517 spike-08.openstreetmap.org)",
+#'   "copyright": "OpenStreetMap and contributors",
+#'   "attribution": "http://www.openstreetmap.org/copyright",
+#'   "license": "http://opendatacommons.org/licenses/odbl/1-0/",
+#'   "changesets": [
+#'     {
+#'       "id": 10,
+#'       "created_at": "2005-05-01T16:09:37Z",
+#'       "open": false,
+#'       "comments_count": 1,
+#'       "changes_count": 10,
+#'       "closed_at": "2005-05-01T17:16:44Z",
+#'       "min_lat": 59.9513092,
+#'       "min_lon": 10.7719727,
+#'       "max_lat": 59.9561501,
+#'       "max_lon": 10.7994537,
+#'       "uid": 24,
+#'       "user": "Petter Reinholdtsen",
+#'       "tags": {
+#'           "comment": "Just adding some streetnames",
+#'           "created_by": "JOSM 1.61"
+#'       }
+#'     },
+#'     ...
+#'   ]
 #' }
 #' ```
 #'

--- a/R/osmapi_elements.R
+++ b/R/osmapi_elements.R
@@ -250,7 +250,7 @@ osm_read_object <- function(osm_type = c("node", "way", "relation"),
 
 
 ## Update: `PUT /api/0.6/[node|way|relation]/#id` ----
-# Updates data from a preexisting element. A full representation of the element as it should be after the update has to be provided. Any tags, way-node refs, and relation members that remain unchanged must be in the update as well. A version number must be provided as well, it must match the current version of the element in the database.
+# Updates data from a preexisting element. A full representation of the element as it should be after the update has to be provided. Any tags, way-node refs, and relation members that remain unchanged must be in the update as well. A version number must be provided as well, it '''must match''' the current version of the element in the database.
 #
 # This example is an update of the node 4326396331, updating the version 1 to alter existing tags. This change is made while the changeset with id 188021 is still open:
 # <syntaxhighlight lang="xml">
@@ -261,15 +261,29 @@ osm_read_object <- function(osm_type = c("node", "way", "relation"),
 # </osm>
 # </syntaxhighlight>
 #
+# Example for way 22935194 adding a new key zoning_code with value B. Remember that when making the PUT to an existing way, you need to add all existing tags (excluded here some for brevity) and the same version as the version from OSM
+#
+# <syntaxhighlight lang="xml">
+#   <osm>
+#     <way id="22935194" changeset="152700179" version="9">
+#       <tag k="highway" v="residential"/>
+#       <tag k="zoning_code" v="B"/>
+#       <tag k="name" v="Strada Desseanu"/>
+#     </way>
+#   </osm>
+# </syntaxhighlight>
+#
+#
 ### Response ----
 # Returns the new version number with a content type of `text/plain`.
 #
 ### Error codes ----
 # ; HTTP status code 400 (Bad Request) - `text/plain`
-# : When there are errors parsing the XML. A text message explaining the error is returned. This can also happen if you forget to pass the Content-Length header.
+# : When there are errors parsing the XML. A text message explaining the error is returned.  (Example:  Version is required when updating) This can also happen if you forget to pass the Content-Length header.
 # : When a changeset ID is missing (unfortunately the error messages are not consistent)
 # : When a node is outside the world
 # : When there are too many nodes for a way
+# :
 # ; HTTP status code 409 (Conflict) - `text/plain`
 # : When the version of the provided element does not match the current database version of the element
 # : If the changeset in question has already been closed (either by the user itself or as a result of the auto-closing feature). A message with the format "`The changeset #id was closed at #closed_at.`" is returned
@@ -525,7 +539,7 @@ osm_delete_object <- function(x, changeset_id) {
 
 
 ## History: `GET /api/0.6/[node|way|relation]/#id/history` ----
-# Retrieves all old versions of an element. ([https://api.openstreetmap.org/api/0.6/way/250066046/history example])
+# Retrieves all old versions of an element, sorted by version number from oldest to newest. ([https://api.openstreetmap.org/api/0.6/way/250066046/history example])
 #
 ### Error codes ----
 # ; HTTP status code 404 (Not Found)
@@ -662,7 +676,7 @@ osm_version_object <- function(osm_type = c("node", "way", "relation"), osm_id, 
 ### Parameters ----
 # ; [nodes|ways|relations]=comma separated list
 # : The parameter has to be the same in the URL (e.g. /api/0.6/nodes?nodes=123,456,789)
-# : Version numbers for each object may be optionally provided following a lowercase "v" character, e.g. /api/0.6/nodes?nodes=421586779v1,421586779v2
+# : Version numbers for each object may be optionally provided following a lowercase "v" character, e.g. /api/0.6/nodes?nodes=421586779v1,421586779v2  (Currently supported only in CGImap, used on osm.org https://github.com/openstreetmap/openstreetmap-website/pull/1189/)
 #
 ### Error codes ----
 # ; HTTP status code 400 (Bad Request)
@@ -1042,7 +1056,7 @@ osm_full_object <- function(osm_type = c("way", "relation"), osm_id,
 #
 ### Notes ----
 # * only permitted for OSM accounts with the moderator role (DWG and server admins)
-# * requires either <code>write_redactions</code> or <code>write_api</code> OAuth scope; <code>write_redactions</code> is being phased out
+# * requires <code>write_redactions</code> OAuth scope; before September 2024 required either <code>write_api</code> or <code>write_redactions</code>, and before December 2023 required <code>write_api</code>; those older scope requirements may still be around on other openstreetmap-website-based servers such as [[OpenHistoricalMap]]
 # * the #redaction_id is listed on https://www.openstreetmap.org/redactions
 # * more information can be found in [https://git.openstreetmap.org/rails.git/blob/HEAD:/app/controllers/redactions_controller.rb the source]
 # * This is an extremely specialized call

--- a/R/osmapi_elements.R
+++ b/R/osmapi_elements.R
@@ -312,7 +312,7 @@ osm_read_object <- function(osm_type = c("node", "way", "relation"),
 #' @details
 #' A full representation of the element as it should be after the update has to be provided. Any tags, way-node refs,
 #' and relation members that remain unchanged must be in the update as well. A version number must be provided as well,
-#' it must match the current version of the element in the database.
+#' it **must match** the current version of the element in the database.
 #'
 #' If `x` is a data.frame, the columns `type`, `id`, `visible`, `version`, `changeset`, and `tags` must be present +
 #' column `members` for ways and relations + `lat` and `lon` for nodes. For the xml format, see the
@@ -547,7 +547,7 @@ osm_delete_object <- function(x, changeset_id) {
 
 #' Get the history of an object
 #'
-#' Retrieves all old versions of an object from OSM.
+#' Retrieves all old versions of an object from OSM, sorted by version number from oldest to newest.
 #'
 #' @param osm_type Object type (`"node"`, `"way"` or `"relation"`).
 #' @param osm_id Object id represented by a numeric or a character value.
@@ -1080,6 +1080,11 @@ osm_full_object <- function(osm_type = c("way", "relation"), osm_id,
 #' @details
 #' The `redaction_id` is listed on <https://www.openstreetmap.org/redactions>. More information can be found in
 #' [the source](https://git.openstreetmap.org/rails.git/blob/HEAD:/app/controllers/redactions_controller.rb).
+#'
+#' @note
+#' Requires `write_redactions` OAuth scope; before September 2024 required either `write_api` or `write_redactions`, and
+#' before December 2023 required `write_api`; those older scope requirements may still be around on other
+#' openstreetmap-website-based servers such as [OpenHistoricalMap](https://www.openhistoricalmap.org).
 #'
 #' @return Nothing is returned upon successful redaction or unredaction of an object.
 #' @family functions for moderators

--- a/R/osmapi_miscellaneous.R
+++ b/R/osmapi_miscellaneous.R
@@ -319,6 +319,7 @@ osm_bbox_objects <- function(bbox, format = c("R", "xml", "json"), tags_in_colum
 # * allow_write_prefs (modify user preferences)
 # * allow_write_diary (create diary entries, comments and make friends)
 # * allow_write_api (modify the map)
+# * allow_write_redactions (redact element versions)
 # * allow_read_gpx (read private GPS traces)
 # * allow_write_gpx (upload GPS traces)
 # * allow_write_notes (modify notes)

--- a/R/osmapi_miscellaneous.R
+++ b/R/osmapi_miscellaneous.R
@@ -337,6 +337,7 @@ osm_bbox_objects <- function(bbox, format = c("R", "xml", "json"), tags_in_colum
 #' * allow_write_prefs (modify user preferences)
 #' * allow_write_diary (create diary entries, comments and make friends)
 #' * allow_write_api (modify the map)
+#' * allow_write_redactions (redact element versions)
 #' * allow_read_gpx (read private GPS traces)
 #' * allow_write_gpx (upload GPS traces)
 #' * allow_write_notes (modify notes)

--- a/R/osmapi_user_data.R
+++ b/R/osmapi_user_data.R
@@ -415,7 +415,7 @@ osm_details_logged_user <- function(format = c("R", "xml", "json")) {
 }
 
 
-## Preferences of the logged-in user: `GET /api/0.6/user/preferences` ----
+## Preferences of the logged-in user: `GET|PUT|DELETE /api/0.6/user/preferences` ----
 # The OSM server supports storing arbitrary user preferences. This can be used by editors, for example, to offer the same configuration wherever the user logs in, instead of a locally-stored configuration. For an overview of applications using the preferences-API and which key-schemes they use, see [[preferences|this wiki page]].
 #
 # You can retrieve the list of current preferences using

--- a/inst/WORDLIST
+++ b/inst/WORDLIST
@@ -45,6 +45,7 @@ cdf
 ce
 cff
 CGImap
+cgimap
 Changelog
 changelogs
 changeset
@@ -102,6 +103,7 @@ deca
 del
 desc
 describeIn
+Desseanu
 dev
 developmentStatus
 devtools
@@ -292,6 +294,8 @@ OLTAmk
 onAttach
 onLoad
 opendatacommons
+OpenHistoricalMap
+openhistoricalmap
 OpenStreetBugs
 openstreetmap
 OpenStreetMap
@@ -321,6 +325,7 @@ OsmChange's
 osmdata
 osmextract
 osmfoundation
+OSMWikiVersion
 osn
 outL
 packageEvent
@@ -422,6 +427,7 @@ spdx
 sprintf
 stdlib
 stopifnot
+Strada
 streetnames
 strftime
 strsplit

--- a/man/osm_get_changesets.Rd
+++ b/man/osm_get_changesets.Rd
@@ -29,50 +29,68 @@ from \pkg{sf}.
 
 Returns a \link[xml2:oldclass]{xml2::xml_document} with the following format:
 
-\if{html}{\out{<div class="sourceCode xml">}}\preformatted{<osm>
-	<changeset id="10" created_at="2008-11-08T19:07:39+01:00" open="true" user="fred" uid="123" min_lon="7.0191821" min_lat="49.2785426" max_lon="7.0197485" max_lat="49.2793101" comments_count="3" changes_count="10">
-		<tag k="created_by" v="JOSM 1.61"/>
-		<tag k="comment" v="Just adding some streetnames"/>
-		...
-		<discussion>
-			<comment date="2015-01-01T18:56:48Z" uid="1841" user="metaodi">
-				<text>Did you verify those street names?</text>
-			</comment>
-			<comment date="2015-01-01T18:58:03Z" uid="123" user="fred">
-				<text>sure!</text>
-			</comment>
-			...
-		</discussion>
-	</changeset>
-	<changeset>
-	  ...
-	</changeset>
+\if{html}{\out{<div class="sourceCode xml">}}\preformatted{<osm version="0.6" generator="CGImap 0.9.3 (987909 spike-08.openstreetmap.org)" copyright="OpenStreetMap and contributors" attribution="http://www.openstreetmap.org/copyright" license="http://opendatacommons.org/licenses/odbl/1-0/">
+  <changeset id="10" created_at="2008-11-08T19:07:39+01:00" open="true" user="fred" uid="123" min_lon="7.0191821" min_lat="49.2785426" max_lon="7.0197485" max_lat="49.2793101" comments_count="3" changes_count="10">
+    <tag k="created_by" v="JOSM 1.61"/>
+    <tag k="comment" v="Just adding some streetnames"/>
+    ...
+    <discussion>
+      <comment id="1234" date="2015-01-01T18:56:48Z" uid="1841" user="metaodi">
+        <text>Did you verify those street names?</text>
+      </comment>
+      <comment id="5678" date="2015-01-01T18:58:03Z" uid="123" user="fred">
+        <text>sure!</text>
+      </comment>
+      ...
+    </discussion>
+  </changeset>
+  <changeset>
+    ...
+  </changeset>
 </osm>
 }\if{html}{\out{</div>}}
 }
 
 \subsection{\code{format = "json"}}{
 
+\emph{Please note that the JSON format has changed on August 25, 2024 with the release of openstreetmap-cgimap 2.0.0, to}
+\emph{align it with the existing Rails format.}
+
 Returns a list with the following json structure:
 
 \if{html}{\out{<div class="sourceCode json">}}\preformatted{\{
- "version": "0.6",
- "elements": [
-  \{"type": "changeset",
-   "id": 10,
-   "created_at": "2005-05-01T16:09:37Z",
-   "closed_at": "2005-05-01T17:16:44Z",
-   "open": False,
-   "user": "Petter Reinholdtsen",
-   "uid": 24,
-   "minlat": 59.9513092,
-   "minlon": 10.7719727,
-   "maxlat": 59.9561501,
-   "maxlon": 10.7994537,
-   "comments_count": 1,
-   "changes_count": 10,
-   "discussion": [\{"date": "2022-03-22T20:58:30Z", "uid": 15079200, "user": "Ethan White of Cheriton", "text": "wow no one have said anything here 3/22/2022\\n"\}]
-  \}, ...]
+  "version": "0.6",
+  "generator": "openstreetmap-cgimap 2.0.0 (4003517 spike-08.openstreetmap.org)",
+  "copyright": "OpenStreetMap and contributors",
+  "attribution": "http://www.openstreetmap.org/copyright",
+  "license": "http://opendatacommons.org/licenses/odbl/1-0/",
+  "changeset": [
+    \{
+      "id": 10,
+      "created_at": "2005-05-01T16:09:37Z",
+      "open": false,
+      "comments_count": 1,
+      "changes_count": 10,
+      "closed_at": "2005-05-01T17:16:44Z",
+      "min_lat": 59.9513092,
+      "min_lon": 10.7719727,
+      "max_lat": 59.9561501,
+      "max_lon": 10.7994537,
+      "uid": 24,
+      "user": "Petter Reinholdtsen",
+      "comments": [
+        \{
+          "id": 836447,
+          "visible": true,
+          "date": "2022-03-22T20:58:30Z",
+          "uid": 15079200,
+          "user": "Ethan White of Cheriton",
+          "text": "wow no one have said anything here 3/22/2022\\n"
+        \}
+      ]
+    \},
+    ...
+  ]
 \}
 }\if{html}{\out{</div>}}
 }

--- a/man/osm_history_object.Rd
+++ b/man/osm_history_object.Rd
@@ -29,7 +29,7 @@ If \code{format = "R"}, returns a data frame with a version of the OSM object pe
 returns a list with a json structure following the \href{https://wiki.openstreetmap.org/wiki/OSM_JSON}{OSM_JSON format}.
 }
 \description{
-Retrieves all old versions of an object from OSM.
+Retrieves all old versions of an object from OSM, sorted by version number from oldest to newest.
 }
 \examples{
 node <- osm_history_object(osm_type = "node", osm_id = 35308286)

--- a/man/osm_permissions.Rd
+++ b/man/osm_permissions.Rd
@@ -24,6 +24,7 @@ Currently the following permissions can appear in the result, corresponding dire
 \item allow_write_prefs (modify user preferences)
 \item allow_write_diary (create diary entries, comments and make friends)
 \item allow_write_api (modify the map)
+\item allow_write_redactions (redact element versions)
 \item allow_read_gpx (read private GPS traces)
 \item allow_write_gpx (upload GPS traces)
 \item allow_write_notes (modify notes)

--- a/man/osm_query_changesets.Rd
+++ b/man/osm_query_changesets.Rd
@@ -52,50 +52,53 @@ from \pkg{sf}.
 
 Returns a \link[xml2:oldclass]{xml2::xml_document} with the following format:
 
-\if{html}{\out{<div class="sourceCode xml">}}\preformatted{<osm>
-	<changeset id="10" created_at="2008-11-08T19:07:39+01:00" open="true" user="fred" uid="123" min_lon="7.0191821" min_lat="49.2785426" max_lon="7.0197485" max_lat="49.2793101" comments_count="3" changes_count="10">
-		<tag k="created_by" v="JOSM 1.61"/>
-		<tag k="comment" v="Just adding some streetnames"/>
-		...
-		<discussion>
-			<comment date="2015-01-01T18:56:48Z" uid="1841" user="metaodi">
-				<text>Did you verify those street names?</text>
-			</comment>
-			<comment date="2015-01-01T18:58:03Z" uid="123" user="fred">
-				<text>sure!</text>
-			</comment>
-			...
-		</discussion>
-	</changeset>
-	<changeset ...>
-	  ...
-	</changeset>
+\if{html}{\out{<div class="sourceCode xml">}}\preformatted{<osm version="0.6" generator="OpenStreetMap server" copyright="OpenStreetMap and contributors" attribution="http://www.openstreetmap.org/copyright" license="http://opendatacommons.org/licenses/odbl/1-0/">
+  <changeset id="10" created_at="2005-05-01T16:09:37Z" open="false" comments_count="1" changes_count="10" closed_at="2005-05-01T17:16:44Z" min_lat="59.9513092" min_lon="10.7719727" max_lat="59.9561501" max_lon="10.7994537" uid="24" user="Petter Reinholdtsen">
+    <tag k="created_by" v="JOSM 1.61"/>
+    <tag k="comment" v="Just adding some streetnames"/>
+    ...
+  </changeset>
+  <changeset ...>
+    ...
+  </changeset>
 </osm>
 }\if{html}{\out{</div>}}
 }
 
 \subsection{\code{format = "json"}}{
 
+\emph{Please note that the JSON format has changed on August 25, 2024 with the release of openstreetmap-cgimap 2.0.0, to}
+\emph{align it with the existing Rails format.}
+
 Returns a list with the following json structure:
 
 \if{html}{\out{<div class="sourceCode json">}}\preformatted{\{
- "version": "0.6",
- "elements": [
-  \{"type": "changeset",
-   "id": 10,
-   "created_at": "2005-05-01T16:09:37Z",
-   "closed_at": "2005-05-01T17:16:44Z",
-   "open": False,
-   "user": "Petter Reinholdtsen",
-   "uid": 24,
-   "minlat": 59.9513092,
-   "minlon": 10.7719727,
-   "maxlat": 59.9561501,
-   "maxlon": 10.7994537,
-   "comments_count": 1,
-   "changes_count": 10,
-   "discussion": [\{"date": "2022-03-22T20:58:30Z", "uid": 15079200, "user": "Ethan White of Cheriton", "text": "wow no one have said anything here 3/22/2022\\n"\}]
-  \}, ...]
+  "version": "0.6",
+  "generator": "openstreetmap-cgimap 2.0.0 (4003517 spike-08.openstreetmap.org)",
+  "copyright": "OpenStreetMap and contributors",
+  "attribution": "http://www.openstreetmap.org/copyright",
+  "license": "http://opendatacommons.org/licenses/odbl/1-0/",
+  "changesets": [
+    \{
+      "id": 10,
+      "created_at": "2005-05-01T16:09:37Z",
+      "open": false,
+      "comments_count": 1,
+      "changes_count": 10,
+      "closed_at": "2005-05-01T17:16:44Z",
+      "min_lat": 59.9513092,
+      "min_lon": 10.7719727,
+      "max_lat": 59.9561501,
+      "max_lon": 10.7994537,
+      "uid": 24,
+      "user": "Petter Reinholdtsen",
+      "tags": \{
+          "comment": "Just adding some streetnames",
+          "created_by": "JOSM 1.61"
+      \}
+    \},
+    ...
+  ]
 \}
 }\if{html}{\out{</div>}}
 }

--- a/man/osm_query_changesets.Rd
+++ b/man/osm_query_changesets.Rd
@@ -9,6 +9,8 @@ osm_query_changesets(
   user,
   time,
   time_2,
+  from,
+  to,
   open,
   closed,
   changeset_ids,
@@ -26,7 +28,13 @@ osm_query_changesets(
 \item{time}{Find changesets \strong{closed} after this date and time. See details for the valid formats.}
 
 \item{time_2}{find changesets that were \strong{closed} after \code{time} and \strong{created} before \code{time_2}. In other words, any
-changesets that were open \strong{at some time} during the given time range \code{time} to \code{time_2}.}
+changesets that were open \strong{at some time} during the given time range \code{time} to \code{time_2}.  See details for the
+valid formats.}
+
+\item{from}{Find changesets \strong{created} at or after this value. See details for the valid formats.}
+
+\item{to}{Find changesets \strong{created} before this value. \code{to} requires \code{from}, but not vice-versa. If \code{to} is
+provided alone, it has no effect. See details for the valid formats.}
 
 \item{open}{If \code{TRUE}, only finds changesets that are still \strong{open} but excludes changesets that are closed or have
 reached the element limit for a changeset (10,000 at the moment \code{osm_capabilities()$api$changesets}).}
@@ -120,8 +128,9 @@ This call returns latest changesets matching criteria. The default ordering is n
 – see the \href{https://github.com/openstreetmap/openstreetmap-website/blob/master/app/controllers/api/changesets_controller.rb#L174}{current state}).
 Reverse ordering cannot be combined with \code{time}.
 
-Te valid formats for \code{time} and \code{time_2} parameters are anything that
-\href{https://ruby-doc.org/stdlib-2.7.0/libdoc/time/rdoc/Time.html#method-c-parse}{\code{Time.parse} Ruby function} will parse.
+Te valid formats for \code{time}, \code{time_2}, \code{from} and \code{to} parameters are \link{POSIXt} values or characters with anything
+that \href{https://ruby-doc.org/stdlib-2.7.0/libdoc/time/rdoc/Time.html#method-c-parse}{\code{Time.parse} Ruby function} will
+parse.
 }
 \examples{
 chst_ids <- osm_query_changesets(changeset_ids = c(137627129, 137625624))

--- a/man/osm_redaction_object.Rd
+++ b/man/osm_redaction_object.Rd
@@ -33,6 +33,11 @@ elements containing data privacy or copyright infringements. Only permitted for 
 The \code{redaction_id} is listed on \url{https://www.openstreetmap.org/redactions}. More information can be found in
 \href{https://git.openstreetmap.org/rails.git/blob/HEAD:/app/controllers/redactions_controller.rb}{the source}.
 }
+\note{
+Requires \code{write_redactions} OAuth scope; before September 2024 required either \code{write_api} or \code{write_redactions}, and
+before December 2023 required \code{write_api}; those older scope requirements may still be around on other
+openstreetmap-website-based servers such as \href{https://www.openhistoricalmap.org}{OpenHistoricalMap}.
+}
 \examples{
 \dontrun{
 ## WARNING: this example will edit the OSM (testing) DB with your user!

--- a/man/osm_update_object.Rd
+++ b/man/osm_update_object.Rd
@@ -22,7 +22,7 @@ Updates data from a preexisting element.
 \details{
 A full representation of the element as it should be after the update has to be provided. Any tags, way-node refs,
 and relation members that remain unchanged must be in the update as well. A version number must be provided as well,
-it must match the current version of the element in the database.
+it \strong{must match} the current version of the element in the database.
 
 If \code{x} is a data.frame, the columns \code{type}, \code{id}, \code{visible}, \code{version}, \code{changeset}, and \code{tags} must be present +
 column \code{members} for ways and relations + \code{lat} and \code{lon} for nodes. For the xml format, see the

--- a/tests/testthat/_snaps/changesets.md
+++ b/tests/testthat/_snaps/changesets.md
@@ -205,6 +205,24 @@
     Code
       print(x)
     Output
+               id          created_at           closed_at  open               user
+      1 137626916 2023-06-22 02:05:19 2023-06-22 02:05:19 FALSE Mementomoristultus
+      2 137626898 2023-06-22 02:03:57 2023-06-22 02:03:57 FALSE Mementomoristultus
+             uid    min_lat   min_lon    max_lat   max_lon comments_count
+      1 19648429 38.9100720 1.4302823 38.9101137 1.4304540              1
+      2 19648429 38.8835173 1.3845938 38.9299968 1.4634214              0
+        changes_count
+      1             1
+      2             1
+                                                                                       tags
+      1 6 tags: changesets_count=146 | comment=23 | created_by=iD 2.25.2 | host=https://...
+      2 6 tags: changesets_count=145 | comment=112 | created_by=iD 2.25.2 | host=https:/...
+
+---
+
+    Code
+      print(x)
+    Output
                 id          created_at           closed_at  open               user
       1  137626978 2023-06-22 02:10:24 2023-06-22 02:10:24 FALSE Mementomoristultus
       2  137626972 2023-06-22 02:09:43 2023-06-22 02:09:44 FALSE Mementomoristultus

--- a/tests/testthat/mock_query_changesets/osm.org/api/0.6/changesets-b87e70.xml
+++ b/tests/testthat/mock_query_changesets/osm.org/api/0.6/changesets-b87e70.xml
@@ -1,0 +1,19 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<osm version="0.6" generator="OpenStreetMap server" copyright="OpenStreetMap and contributors" attribution="http://www.openstreetmap.org/copyright" license="http://opendatacommons.org/licenses/odbl/1-0/">
+<changeset id="137626916" created_at="2023-06-22T02:05:19Z" open="false" comments_count="1" changes_count="1" closed_at="2023-06-22T02:05:19Z" min_lat="38.9100720" min_lon="1.4302823" max_lat="38.9101137" max_lon="1.4304540" uid="19648429" user="Mementomoristultus">
+  <tag k="changesets_count" v="146"/>
+  <tag k="comment" v="23"/>
+  <tag k="created_by" v="iD 2.25.2"/>
+  <tag k="host" v="https://www.openstreetmap.org/edit"/>
+  <tag k="imagery_used" v="PNOA Spain"/>
+  <tag k="locale" v="es"/>
+</changeset>
+<changeset id="137626898" created_at="2023-06-22T02:03:57Z" open="false" comments_count="0" changes_count="1" closed_at="2023-06-22T02:03:57Z" min_lat="38.8835173" min_lon="1.3845938" max_lat="38.9299968" max_lon="1.4634214" uid="19648429" user="Mementomoristultus">
+  <tag k="changesets_count" v="145"/>
+  <tag k="comment" v="112"/>
+  <tag k="created_by" v="iD 2.25.2"/>
+  <tag k="host" v="https://www.openstreetmap.org/edit"/>
+  <tag k="imagery_used" v="PNOA Spain"/>
+  <tag k="locale" v="es"/>
+</changeset>
+</osm>

--- a/tests/testthat/test-changesets.R
+++ b/tests/testthat/test-changesets.R
@@ -267,6 +267,12 @@ test_that("osm_query_changesets works", {
       time = "2023-06-22T02:23:23Z",
       time_2 = "2023-06-22T00:38:20Z"
     )
+    chaset$from_to <- osm_query_changesets(
+      bbox = c(-1.241112, 38.0294955, 8.4203171, 42.9186456),
+      user = "Mementomoristultus",
+      from = as.POSIXlt("2023-06-22T00:38:20Z", tz = "GMT", format = "%Y-%m-%dT%H:%M:%S"),
+      to = as.POSIXlt("2023-06-22T02:23:23Z", tz = "GMT", format = "%Y-%m-%dT%H:%M:%S")
+    )
     chaset$closed <- osm_query_changesets(
       bbox = "-9.3015367,41.8073642,-6.7339533,43.790422",
       user = "Mementomoristultus",

--- a/tests/testthat/test-user_data.R
+++ b/tests/testthat/test-user_data.R
@@ -126,7 +126,7 @@ test_that("osm_details_logged_user works", {
 })
 
 
-## Preferences of the logged-in user: `GET /api/0.6/user/preferences` ----
+## Preferences of the logged-in user: `GET|PUT|DELETE /api/0.6/user/preferences` ----
 
 test_that("osm_set-get_preferences_user works", {
   with_mock_dir("mock_get_prefs_user", {


### PR DESCRIPTION
See changes at https://wiki.openstreetmap.org/w/index.php?title=API_v0.6&type=revision&diff=2775892&oldid=2711808

* Added DESCRIPTION field OSMWikiVersion with the wiki page version
* `osm_query_changesets()` add the new parameters `from` and `to`.