### PR TITLE
Fix for upcoming httr2 1.2.0 release

### DIFF
--- a/R/osmapi_changesets.R
+++ b/R/osmapi_changesets.R
@@ -313,10 +313,9 @@ osm_read_changeset <- function(changeset_id, include_discussion = FALSE,
   req <- osmapi_request()
   req <- httr2::req_method(req, "GET")
 
+  req <- httr2::req_url_path_append(req, "changeset", changeset_id)
   if (include_discussion) {
-    req <- httr2::req_url_path_append(req, "changeset", paste0(changeset_id, "?include_discussion='true'"))
-  } else {
-    req <- httr2::req_url_path_append(req, "changeset", changeset_id)
+    req <- httr2::req_url_query(req, include_discussion = I("'true'"))
   }
 
   resp <- httr2::req_perform(req)


### PR DESCRIPTION
`req_url_path_append()` now escapes all special characters, so we have to use `req_url_query()` instead. `req_url_query()` also now escapes value, so we wrap it in `I()` to prevent that (that probably doesn't affect the actual API usage but ensures that your httptest2 mocks continue to work).