### PR TITLE
Test with upcoming httr2

### DIFF
--- a/DESCRIPTION
+++ b/DESCRIPTION
@@ -36,3 +36,4 @@ Roxygen: list(markdown = TRUE)
 RoxygenNote: 7.3.2
 X-schema.org-keywords: open street map, openstreetmap, OSM,
     openstreetmap-api, osmapi, API
+Remotes: r-lib/httr2

--- a/DESCRIPTION
+++ b/DESCRIPTION
@@ -36,4 +36,3 @@ Roxygen: list(markdown = TRUE)
 RoxygenNote: 7.3.2
 X-schema.org-keywords: open street map, openstreetmap, OSM,
     openstreetmap-api, osmapi, API
-Remotes: r-lib/httr2

--- a/tests/testthat/test-osmapiR_request.R
+++ b/tests/testthat/test-osmapiR_request.R
@@ -37,7 +37,7 @@ test_that("error handling works", {
         httr2::req_url_path_append("nodes") |>
         httr2::req_url_query(nodes = paste(1:2000, collapse = ",")) |>
         httr2::req_perform(),
-      "414 URI Too Long.+The requested URL's length exceeds the capacity\nlimit for this server."
+      class = 'httr2_http_414'
     )
   })
 })


### PR DESCRIPTION
As you can see from the CI ❌ below, there was still a problem with the new httr2. Some error messaging slightly changed. Fixed this by testing against the error class instead of message, which will never change.