### PR TITLE
bbox parameters now accepts more formats implemented in bbox_to_string()

### DIFF
--- a/DESCRIPTION
+++ b/DESCRIPTION
@@ -1,7 +1,7 @@
 Type: Package
 Package: osmapiR
 Title: 'OpenStreetMap' API
-Version: 0.2.4.9004
+Version: 0.2.4.9005
 Authors@R: c(
     person("Joan", "Maspons", , "joanmaspons@gmail.com", role = c("aut", "cre", "cph"),
            comment = c(ORCID = "0000-0003-2286-8727")),

--- a/NEWS.md
+++ b/NEWS.md
@@ -3,6 +3,8 @@
 * Update documentation and code for server-side changes documented in OSMWikiVersion
   [2878437 -> 2940426](https://wiki.openstreetmap.org/w/index.php?title=API_v0.6&diff=2940426&oldid=2878437) (#72).
   * Add new function `osm_search_comment_changeset_discussion()`.
+* `bbox` parameters now accepts more formats, including character, matrix, vector, `bbox` object from `sf` package, or a
+  `SpatExtent` from `terra` package (#73).
 
 # osmapiR 0.2.4
 

--- a/R/bbox_to_string.R
+++ b/R/bbox_to_string.R
@@ -1,0 +1,70 @@
+#' Convert a named matrix or a named or unnamed vector to a bbox string
+#'
+#' This function converts a bounding box into a string for use in web api calls
+#'
+#' @param bbox bounding box in degrees as character, matrix, vector, `bbox` object from \pkg{sf}, a `SpatExtent` from
+#'   \pkg{terra}. Unnamed vectors and matrices will be sorted appropriately and must merely be in the order (x, y, x, y)
+#'   or x in the first column and y in the second column.
+#'
+#' @return A character string representing the left, bottom, right, top bounds. For example:
+#' "-1.241112,38.0294955,8.4203171,42.9186456" is the bounding box for the Catalan Countries.
+#'
+#' @note function adapted from osmdata package.
+#' @noRd
+#'
+#' @examples
+#' bb <- c(xmin = -1.241112, ymin = 38.0294955, xmax = 8.4203171, ymax = 42.9186456)
+#' bbox_to_string(bb)
+#' bb <- c(ymin = 38.0294955, xmin = -1.241112, ymax = 42.9186456, xmax = 8.4203171)
+#' bbox_to_string(bb)
+bbox_to_string <- function(bbox) {
+  if (is.null(bbox)) {
+    return(NULL)
+  }
+
+  if (inherits(bbox, "matrix")) {
+    if (nrow(bbox) > 2) {
+      bbox <- apply(bbox, 2, range)
+    }
+
+    if (all(c("x", "y") %in% tolower(rownames(bbox))) & all(c("min", "max") %in% tolower(colnames(bbox)))) {
+      bbox <- c(
+        bbox["x", "min"], bbox["y", "min"],
+        bbox["x", "max"], bbox["y", "max"]
+      )
+    } else if (all(c("coords.x1", "coords.x2") %in% rownames(bbox)) & all(c("min", "max") %in% colnames(bbox))) {
+      bbox <- c(
+        bbox["coords.x1", "min"], bbox["coords.x2", "min"],
+        bbox["coords.x1", "max"], bbox["coords.x2", "max"]
+      )
+    } else {
+      # otherwise just presume (x,y) are columns and order the rows
+      bbox <- c(
+        min(bbox[, 1]), min(bbox[, 2]),
+        max(bbox[, 1]), max(bbox[, 2])
+      )
+    }
+  } else if (is.numeric(bbox)) {
+    if (length(bbox) < 4) {
+      stop("bbox must contain four elements")
+    } else if (length(bbox) > 4) {
+      message("only the first four elements of bbox used")
+    }
+
+    if (!is.null(names(bbox))) {
+      if (all(names(bbox) %in% c("left", "bottom", "right", "top"))) {
+        bbox <- bbox[c("left", "bottom", "right", "top")]
+      } else if (all(names(bbox) %in% c("xmin", "xmax", "ymin", "ymax"))) { # sf::st_bbox()
+        bbox <- bbox[c("xmin", "ymin", "xmax", "ymax")]
+      }
+    } else { # assume c(xmin, ymin, xmax, ymax)
+      x <- sort(bbox[c(1, 3)])
+      y <- sort(bbox[c(2, 4)])
+      bbox <- c(x[1], y[1], x[2], y[2])
+    }
+  } else if (inherits(bbox, "SpatExtent")) { # terra::ext()
+    bbox <- bbox@pntr$vector # equivalent to as.vector(bbox) but without depending on terra pkg
+  }
+
+  return(paste0(bbox, collapse = ","))
+}

--- a/R/osm_get_points_gps.R
+++ b/R/osm_get_points_gps.R
@@ -4,7 +4,9 @@
 #'
 #' @param bbox Coordinates for the area to retrieve the notes from (`left,bottom,right,top`). Floating point numbers in
 #'   degrees, expressing a valid bounding box. The maximal width (`right - left`) and height (`top - bottom`) of the
-#'   bounding box is 0.25 degree.
+#'   bounding box is 0.25 degree. It can be specified by a character, matrix, vector, `bbox` object from \pkg{sf}, a
+#'   `SpatExtent` from \pkg{terra}. Unnamed vectors and matrices will be sorted appropriately and must merely be in the
+#'   order (`x`, `y`, `x`, `y`) or `x` in the first column and `y` in the second column.
 #' @param page_number Specifies which groups of 5,000 points, or page, to return. The API call does not return more
 #'   than 5,000 points at a time. In order to retrieve all of the points for a bounding box, set `page_number = -1`.
 #'   When this parameter is 0 (zero), the command returns the first 5,000 points; when it is 1, the command returns
@@ -72,7 +74,7 @@ osm_get_points_gps <- function(bbox, page_number = 0, format = c("R", "sf", "sf_
     .format <- format
   }
 
-  bbox <- paste(bbox, collapse = ",")
+  bbox <- bbox_to_string(bbox)
 
   if (page_number >= 0) { # concrete pages
     outL <- lapply(page_number, function(x) .osm_get_points_gps(bbox = bbox, page_number = x, format = .format))

--- a/R/osm_query_changesets.R
+++ b/R/osm_query_changesets.R
@@ -2,7 +2,10 @@
 #'
 #' This is an API method for querying changesets. It supports querying by different criteria.
 #'
-#' @param bbox Find changesets within the given bounding box coordinates (`left,bottom,right,top`).
+#' @param bbox Find changesets within the given bounding box coordinates (`left,bottom,right,top`). It can be specified
+#'   by a character, matrix, vector, `bbox` object from \pkg{sf}, a `SpatExtent` from \pkg{terra}. Unnamed vectors and
+#'   matrices will be sorted appropriately and must merely be in the order (`x`, `y`, `x`, `y`) or `x` in the first
+#'   column and `y` in the second column.
 #' @param user Find changesets by the user with the given user id (numeric) or display name (character).
 #' @param time Find changesets **closed** after this date and time. See details for the valid formats.
 #' @param time_2 find changesets that were **closed** after `time` and **created** before `time_2`. In other words, any
@@ -132,7 +135,7 @@ osm_query_changesets <- function(bbox, user, time, time_2, from, to, open, close
   if (missing(bbox)) {
     bbox <- NULL
   } else {
-    bbox <- paste(bbox, collapse = ",")
+    bbox <- bbox_to_string(bbox)
   }
 
   if (missing(user)) {

--- a/R/osmapi_changesets.R
+++ b/R/osmapi_changesets.R
@@ -554,7 +554,10 @@ osm_download_changeset <- function(changeset_id, format = c("R", "osc", "xml")) 
 #'
 #' This is an API method for getting a list of changesets. It supports filtering by different criteria.
 #'
-#' @param bbox Find changesets within the given bounding box coordinates (`left,bottom,right,top`).
+#' @param bbox Find changesets within the given bounding box coordinates (`left,bottom,right,top`). It can be specified
+#'   by a character, matrix, vector, `bbox` object from \pkg{sf}, a `SpatExtent` from \pkg{terra}. Unnamed vectors and
+#'   matrices will be sorted appropriately and must merely be in the order (`x`, `y`, `x`, `y`) or `x` in the first
+#'   column and `y` in the second column.
 #' @param user Find changesets by the user with the given user id (numeric) or display name (character).
 #' @param time Find changesets **closed** after this date and time. Compare with `from=T1` which filters by creation
 #'   time instead. See details for the valid formats.
@@ -714,7 +717,7 @@ osm_download_changeset <- function(changeset_id, format = c("R", "osc", "xml")) 
   req <- httr2::req_method(req, "GET")
   req <- httr2::req_url_path_append(req, ext)
   req <- httr2::req_url_query(req,
-    bbox = bbox,
+    bbox = bbox_to_string(bbox),
     user = user, display_name = display_name,
     time = time, from = from, to = to,
     open = open, closed = closed,

--- a/R/osmapi_gps_traces.R
+++ b/R/osmapi_gps_traces.R
@@ -49,7 +49,9 @@
 #'
 #' @param bbox Coordinates for the area to retrieve the notes from (`left,bottom,right,top`). Floating point numbers in
 #'   degrees, expressing a valid bounding box. The maximal width (`right - left`) and height (`top - bottom`) of the
-#'   bounding box is 0.25 degree.
+#'   bounding box is 0.25 degree.  It can be specified by a character, matrix, vector, `bbox` object from \pkg{sf}, a
+#'   `SpatExtent` from \pkg{terra}. Unnamed vectors and matrices will be sorted appropriately and must merely be in the
+#'   order (`x`, `y`, `x`, `y`) or `x` in the first column and `y` in the second column.
 #' @param page_number Specifies which group of 5,000 points, or page, to return. Since the command does not return more
 #'   than 5,000 points at a time, this parameter must be incremented —and the command sent again (using the same
 #'   bounding box)— in order to retrieve all of the points for a bounding box that contains more than 5,000 points. When
@@ -102,7 +104,7 @@
   req <- osmapi_request()
   req <- httr2::req_method(req, "GET")
   req <- httr2::req_url_path_append(req, "trackpoints")
-  req <- httr2::req_url_query(req, bbox = paste(bbox, collapse = ","), page = page_number)
+  req <- httr2::req_url_query(req, bbox = bbox_to_string(bbox), page = page_number)
 
   resp <- httr2::req_perform(req)
   obj_xml <- httr2::resp_body_xml(resp)

--- a/R/osmapi_map_notes.R
+++ b/R/osmapi_map_notes.R
@@ -107,7 +107,9 @@
 #'
 #' @param bbox Coordinates for the area to retrieve the notes from (`left,bottom,right,top`). Floating point numbers in
 #'   degrees, expressing a valid bounding box, not larger than the configured size limit, 25 square degrees, not
-#'   overlapping the dateline.
+#'   overlapping the dateline. It can be specified by a character, matrix, vector, `bbox` object from \pkg{sf}, a
+#'   `SpatExtent` from \pkg{terra}. Unnamed vectors and matrices will be sorted appropriately and must merely be in the
+#'   order (`x`, `y`, `x`, `y`) or `x` in the first column and `y` in the second column.
 #' @param limit Specifies the number of entries returned at max. A value between 1 and 10000 is valid. Default to 100.
 #' @param closed Specifies the number of days a note needs to be closed to no longer be returned. A value of 0 means
 #'   only open notes are returned. A value of -1 means all notes are returned. Default to 7.
@@ -202,7 +204,7 @@ osm_read_bbox_notes <- function(bbox, limit = 100, closed = 7, format = c("R", "
   req <- osmapi_request()
   req <- httr2::req_method(req, "GET")
   req <- httr2::req_url_path_append(req, ext)
-  req <- httr2::req_url_query(req, bbox = paste(bbox, collapse = ","), limit = limit, closed = closed)
+  req <- httr2::req_url_query(req, bbox = bbox_to_string(bbox), limit = limit, closed = closed)
 
   resp <- httr2::req_perform(req)
 
@@ -745,8 +747,10 @@ osm_unsubscribe_note <- function(note_id) { # TODO: , format = c("R", "xml", "js
 #' @param user Search for notes which the given user interacted with. The value can be the user id (`numeric`) or the
 #'   display name (`character`).
 #' @param bbox Search area expressed as a string or a numeric vector of 4 coordinates of a valid bounding box
-#'   (`left,bottom,right,top`) in decimal degrees. Area must be at most 25 square degrees (see
-#'   `osm_capabilities()$note_area` and
+#'   (`left,bottom,right,top`) in decimal degrees. It can be specified by a character, matrix, vector, `bbox` object
+#'   from \pkg{sf}, a `SpatExtent` from \pkg{terra}. Unnamed vectors and matrices will be sorted appropriately and must
+#'   merely be in the order (`x`, `y`, `x`, `y`) or `x` in the first column and `y` in the second column. Area must be
+#'   at most 25 square degrees (see `osm_capabilities()$note_area` and
 #'   [this line in settings](https://github.com/openstreetmap/openstreetmap-website/blob/master/config/settings.yml#L27)
 #'   for the current value).
 #' @param from Beginning date range for `created_at` or `updated_at` (specified by `sort`). Preferably in
@@ -816,7 +820,7 @@ osm_search_notes <- function(
   if (missing(bbox)) {
     bbox <- NULL
   } else {
-    bbox <- paste(bbox, collapse = ",")
+    bbox <- bbox_to_string(bbox)
   }
   if (missing(from)) {
     from <- NULL
@@ -885,7 +889,9 @@ osm_search_notes <- function(
 #'   degrees, expressing a valid bounding box, not larger than the configured size limit, 25 square degrees (see
 #'   `osm_capabilities()$note_area` and
 #'   [this line in settings](https://github.com/openstreetmap/openstreetmap-website/blob/master/config/settings.yml#L27)
-#'   for the current value), not overlapping the dateline.
+#'   for the current value), not overlapping the dateline. It can be specified by a character, matrix, vector, `bbox`
+#'   object from \pkg{sf}, a `SpatExtent` from \pkg{terra}. Unnamed vectors and matrices will be sorted appropriately
+#'   and must merely be in the order (`x`, `y`, `x`, `y`) or `x` in the first column and `y` in the second column.
 #'
 #' @return
 #' Returns a [xml2::xml_document-class] in the `RSS` format.
@@ -900,7 +906,7 @@ osm_feed_notes <- function(bbox) {
   req <- osmapi_request()
   req <- httr2::req_method(req, "GET")
   req <- httr2::req_url_path_append(req, "notes", "feed")
-  req <- httr2::req_url_query(req, bbox = paste(bbox, collapse = ","))
+  req <- httr2::req_url_query(req, bbox = bbox_to_string(bbox))
 
   resp <- httr2::req_perform(req)
   obj_xml <- httr2::resp_body_xml(resp)

--- a/R/osmapi_miscellaneous.R
+++ b/R/osmapi_miscellaneous.R
@@ -210,7 +210,10 @@ osm_capabilities <- function() {
 #' * All relations that reference one of the nodes, ways or relations included due to the above rules. (Does '''not'''
 #'   apply recursively, see explanation below.)
 #'
-#' @param bbox Coordinates for the area to retrieve the map data from (`left,bottom,right,top`).
+#' @param bbox Coordinates for the area to retrieve the map data from (`left,bottom,right,top`). It can be specified by
+#'   a character, matrix, vector, `bbox` object from \pkg{sf}, a `SpatExtent` from \pkg{terra}. Unnamed vectors and
+#'   matrices will be sorted appropriately and must merely be in the order (`x`, `y`, `x`, `y`) or `x` in the first
+#'   column and `y` in the second column.
 #' @param format Format of the output. Can be `"R"` (default), `"xml"`, or `"json"`.
 #' @param tags_in_columns If `FALSE` (default), the tags of the objects are saved in a single list column `tags`
 #'   containing a `data.frame` for each OSM object with the keys and values. If `TRUE`, add a column for each key.
@@ -258,7 +261,7 @@ osm_bbox_objects <- function(bbox, format = c("R", "xml", "json"), tags_in_colum
   req <- osmapi_request()
   req <- httr2::req_method(req, "GET")
   req <- httr2::req_url_path_append(req, ext)
-  req <- httr2::req_url_query(req, bbox = paste(bbox, collapse = ","))
+  req <- httr2::req_url_query(req, bbox = bbox_to_string(bbox))
 
   resp <- httr2::req_perform(req)
 

--- a/codemeta.json
+++ b/codemeta.json
@@ -8,13 +8,13 @@
   "codeRepository": "https://github.com/ropensci/osmapiR",
   "issueTracker": "https://github.com/ropensci/osmapiR/issues",
   "license": "https://spdx.org/licenses/GPL-3.0",
-  "version": "0.2.4",
+  "version": "0.2.4.9005",
   "programmingLanguage": {
     "@type": "ComputerLanguage",
     "name": "R",
     "url": "https://r-project.org"
   },
-  "runtimePlatform": "R version 4.5.1 (2025-06-13)",
+  "runtimePlatform": "R version 4.5.2 (2025-10-31)",
   "provider": {
     "@id": "https://cran.r-project.org",
     "@type": "Organization",
@@ -164,7 +164,7 @@
     "SystemRequirements": null
   },
   "keywords": ["openstreetmap", "OSM", "openstreetmap-api", "osmapi", "API", "osm", "r", "r-package"],
-  "fileSize": "14154.876KB",
+  "fileSize": "14187.645KB",
   "citation": [
     {
       "@type": "ScholarlyArticle",
@@ -180,7 +180,7 @@
       ],
       "name": "osmapiR: An 'OpenStreetMap API' implementation for R",
       "identifier": "10.21105/joss.07151",
-      "description": "R package version 0.2.4",
+      "description": "R package version 0.2.4.9005",
       "pagination": "7151",
       "@id": "https://doi.org/10.21105/joss.07151",
       "sameAs": "https://doi.org/10.21105/joss.07151",
@@ -196,13 +196,8 @@
       }
     }
   ],
-  "releaseNotes": "https://github.com/ropensci/osmapiR/blob/master/NEWS.md",
+  "releaseNotes": "https://github.com/ropensci/osmapiR/blob/main/NEWS.md",
   "readme": "https://github.com/ropensci/osmapiR/blob/main/README.md",
   "contIntegration": ["https://github.com/ropensci/osmapiR/actions/workflows/R-CMD-check.yaml", "https://app.codecov.io/gh/ropensci/osmapiR"],
-  "developmentStatus": "https://www.repostatus.org/#active",
-  "review": {
-    "@type": "Review",
-    "url": "https://github.com/ropensci/software-review/issues/633",
-    "provider": "https://ropensci.org"
-  }
+  "developmentStatus": "https://www.repostatus.org/#active"
 }

--- a/inst/WORDLIST
+++ b/inst/WORDLIST
@@ -350,6 +350,7 @@ pkgload
 pkgname
 pkgs
 png
+pntr
 policyL
 pos
 POSIXct
@@ -431,6 +432,7 @@ softwareSuggestions
 somekey
 someLongURLOrOther
 somevalue
+SpatExtent
 spdx
 sprintf
 stdlib
@@ -457,6 +459,7 @@ tibble
 tidyverse
 tinstall
 togpx
+tolower
 topenv
 topografix
 toponimsCat

--- a/man/osm_bbox_objects.Rd
+++ b/man/osm_bbox_objects.Rd
@@ -7,7 +7,10 @@
 osm_bbox_objects(bbox, format = c("R", "xml", "json"), tags_in_columns = FALSE)
 }
 \arguments{
-\item{bbox}{Coordinates for the area to retrieve the map data from (\verb{left,bottom,right,top}).}
+\item{bbox}{Coordinates for the area to retrieve the map data from (\verb{left,bottom,right,top}). It can be specified by
+a character, matrix, vector, \code{bbox} object from \pkg{sf}, a \code{SpatExtent} from \pkg{terra}. Unnamed vectors and
+matrices will be sorted appropriately and must merely be in the order (\code{x}, \code{y}, \code{x}, \code{y}) or \code{x} in the first
+column and \code{y} in the second column.}
 
 \item{format}{Format of the output. Can be \code{"R"} (default), \code{"xml"}, or \code{"json"}.}
 

--- a/man/osm_feed_notes.Rd
+++ b/man/osm_feed_notes.Rd
@@ -11,7 +11,9 @@ osm_feed_notes(bbox)
 degrees, expressing a valid bounding box, not larger than the configured size limit, 25 square degrees (see
 \code{osm_capabilities()$note_area} and
 \href{https://github.com/openstreetmap/openstreetmap-website/blob/master/config/settings.yml#L27}{this line in settings}
-for the current value), not overlapping the dateline.}
+for the current value), not overlapping the dateline. It can be specified by a character, matrix, vector, \code{bbox}
+object from \pkg{sf}, a \code{SpatExtent} from \pkg{terra}. Unnamed vectors and matrices will be sorted appropriately
+and must merely be in the order (\code{x}, \code{y}, \code{x}, \code{y}) or \code{x} in the first column and \code{y} in the second column.}
 }
 \value{
 Returns a \link[xml2:oldclass]{xml2::xml_document} in the \code{RSS} format.

--- a/man/osm_get_points_gps.Rd
+++ b/man/osm_get_points_gps.Rd
@@ -13,7 +13,9 @@ osm_get_points_gps(
 \arguments{
 \item{bbox}{Coordinates for the area to retrieve the notes from (\verb{left,bottom,right,top}). Floating point numbers in
 degrees, expressing a valid bounding box. The maximal width (\code{right - left}) and height (\code{top - bottom}) of the
-bounding box is 0.25 degree.}
+bounding box is 0.25 degree. It can be specified by a character, matrix, vector, \code{bbox} object from \pkg{sf}, a
+\code{SpatExtent} from \pkg{terra}. Unnamed vectors and matrices will be sorted appropriately and must merely be in the
+order (\code{x}, \code{y}, \code{x}, \code{y}) or \code{x} in the first column and \code{y} in the second column.}
 
 \item{page_number}{Specifies which groups of 5,000 points, or page, to return. The API call does not return more
 than 5,000 points at a time. In order to retrieve all of the points for a bounding box, set \code{page_number = -1}.

--- a/man/osm_query_changesets.Rd
+++ b/man/osm_query_changesets.Rd
@@ -21,7 +21,10 @@ osm_query_changesets(
 )
 }
 \arguments{
-\item{bbox}{Find changesets within the given bounding box coordinates (\verb{left,bottom,right,top}).}
+\item{bbox}{Find changesets within the given bounding box coordinates (\verb{left,bottom,right,top}). It can be specified
+by a character, matrix, vector, \code{bbox} object from \pkg{sf}, a \code{SpatExtent} from \pkg{terra}. Unnamed vectors and
+matrices will be sorted appropriately and must merely be in the order (\code{x}, \code{y}, \code{x}, \code{y}) or \code{x} in the first
+column and \code{y} in the second column.}
 
 \item{user}{Find changesets by the user with the given user id (numeric) or display name (character).}
 

--- a/man/osm_read_bbox_notes.Rd
+++ b/man/osm_read_bbox_notes.Rd
@@ -14,7 +14,9 @@ osm_read_bbox_notes(
 \arguments{
 \item{bbox}{Coordinates for the area to retrieve the notes from (\verb{left,bottom,right,top}). Floating point numbers in
 degrees, expressing a valid bounding box, not larger than the configured size limit, 25 square degrees, not
-overlapping the dateline.}
+overlapping the dateline. It can be specified by a character, matrix, vector, \code{bbox} object from \pkg{sf}, a
+\code{SpatExtent} from \pkg{terra}. Unnamed vectors and matrices will be sorted appropriately and must merely be in the
+order (\code{x}, \code{y}, \code{x}, \code{y}) or \code{x} in the first column and \code{y} in the second column.}
 
 \item{limit}{Specifies the number of entries returned at max. A value between 1 and 10000 is valid. Default to 100.}
 

--- a/man/osm_search_notes.Rd
+++ b/man/osm_search_notes.Rd
@@ -24,8 +24,10 @@ osm_search_notes(
 display name (\code{character}).}
 
 \item{bbox}{Search area expressed as a string or a numeric vector of 4 coordinates of a valid bounding box
-(\verb{left,bottom,right,top}) in decimal degrees. Area must be at most 25 square degrees (see
-\code{osm_capabilities()$note_area} and
+(\verb{left,bottom,right,top}) in decimal degrees. It can be specified by a character, matrix, vector, \code{bbox} object
+from \pkg{sf}, a \code{SpatExtent} from \pkg{terra}. Unnamed vectors and matrices will be sorted appropriately and must
+merely be in the order (\code{x}, \code{y}, \code{x}, \code{y}) or \code{x} in the first column and \code{y} in the second column. Area must be
+at most 25 square degrees (see \code{osm_capabilities()$note_area} and
 \href{https://github.com/openstreetmap/openstreetmap-website/blob/master/config/settings.yml#L27}{this line in settings}
 for the current value).}
 

--- a/tests/testthat/test-bbox_to_string.R
+++ b/tests/testthat/test-bbox_to_string.R
@@ -1,0 +1,33 @@
+test_that("bbox_to_string works", {
+  bb <- c(1.8366775, 41.8336843, 1.8379971, 41.8344537)
+  expected <- paste0(bb, collapse = ",")
+  bb_string <- expected
+  bb_named <- stats::setNames(bb, c("xmin", "ymin", "xmax", "ymax"))
+  bb_named2 <- stats::setNames(bb, c("left", "bottom", "right", "top"))
+  bb_mat <- matrix(bb, nrow = 2, ncol = 2, byrow = TRUE)#, dimnames = list(c("min", "max"), c("x", "y")))
+  bb_mat_named <- matrix(bb, nrow = 2, ncol = 2, dimnames = list(c("x", "y"), c("min", "max")))
+  bb_mat_named2 <- matrix(bb, nrow = 2, ncol = 2, dimnames = list(c("coords.x1", "coords.x2"), c("min", "max")))
+
+  expect_identical(bbox_to_string(bb_string), expected)
+  expect_identical(bbox_to_string(bb), expected)
+  expect_identical(bbox_to_string(bb_named), expected)
+  expect_identical(bbox_to_string(bb_named2), expected)
+  expect_identical(bbox_to_string(rev(bb_named)), expected)
+  expect_identical(bbox_to_string(rev(bb_named2)), expected)
+  expect_identical(bbox_to_string(bb_mat), expected)
+  expect_identical(bbox_to_string(bb_mat_named), expected)
+  expect_identical(bbox_to_string(bb_mat_named2), expected)
+
+  if (requireNamespace("sf", quietly = TRUE)) {
+    bb_sf <- sf::st_bbox(bb_named, crs = 4326)
+    expect_identical(bbox_to_string(bb_sf), expected)
+  }
+
+  ## Warning if terra is not in suggested packages
+  # skip_if_not_installed("terra")
+  # bb_terra <- terra::ext(bb)
+  # expect_identical(bbox_to_string(bb_terra), expected)
+
+  expect_error(bbox_to_string(1:3), "bbox must contain four elements")
+  expect_message(bbox_to_string(c(bb, 0)), "only the first four elements of bbox used")
+})


### PR DESCRIPTION
It includes character, matrix, vector, `bbox` object from `sf` package, or a `SpatExtent` from `terra` package