### PR TITLE
Downgrade codecov-action from v7 to v6

### DIFF
--- a/.github/workflows/test-coverage.yaml
+++ b/.github/workflows/test-coverage.yaml
@@ -38,7 +38,7 @@ jobs:
           covr::to_cobertura(cov)
         shell: Rscript {0}
 
-      - uses: codecov/codecov-action@v7
+      - uses: codecov/codecov-action@v6
         with:
           fail_ci_if_error: ${{ github.event_name != 'pull_request' || secrets.CODECOV_TOKEN }}
           file: ./cobertura.xml


### PR DESCRIPTION
v7 seems problematic https://github.com/ropensci/osmapiR/actions/runs/27567731013/job/81495969922